### PR TITLE
fix 'OK' response

### DIFF
--- a/gol.c
+++ b/gol.c
@@ -1177,7 +1177,7 @@ gntp_recv_proc(gpointer user_data) {
         if (notification_display_name) g_free(notification_display_name);
       }
       if (n == notifications_count) {
-        ptr = "GNTP/1.0 OK\r\n\r\n";
+        ptr = "GNTP/1.0 -OK NONE\r\nResponse-Action: REGISTER\r\n\r\n";
         send(sock, ptr, strlen(ptr), 0);
       } else {
         ptr = "GNTP/1.0 -ERROR Invalid data\r\n"
@@ -1254,7 +1254,8 @@ gntp_recv_proc(gpointer user_data) {
       }
 
       if (ni->title && ni->text) {
-        ptr = "GNTP/1.0 OK\r\n\r\n";
+        ptr = g_strdup_printf(
+            "GNTP/1.0 -OK NONE\r\nResponse-Action: %s\r\n\r\n", command);
         send(sock, ptr, strlen(ptr), 0);
 
         gboolean enable = FALSE;


### PR DESCRIPTION
Hi.

I using GNTP Python client(https://github.com/kfdm/gntp/), 
but failed to parse GNTP 'OK' Response.

now::

```
GNTP/1.0 OK
```

fixed::

```
GNTP/1.0 -OK NONE
Response-Action: <messagetype>
```

I referred to GNTP Protocol Specification, following site::
http://www.growlforwindows.com/gfw/help/gntp.aspx

Thanks.
