### PR TITLE
Fix #12: gol SEGVs if the icon URL of a notification is unreachable

### DIFF
--- a/plugins/from_url.c
+++ b/plugins/from_url.c
@@ -50,10 +50,8 @@ memfile_from_url(const memfile_from_url_info info) {
   const CURLcode res = curl_easy_perform(curl);
   curl_easy_cleanup(curl);
 
-  if (res == CURLE_OK) {
-    if (info.body)   *info.body   = memfrelease(&body);
-    if (info.header) *info.header = memfrelease(&header);
-  }
+  if (info.body)   *info.body   = memfrelease(&body);
+  if (info.header) *info.header = memfrelease(&header);
   memfclose(body);
   memfclose(header);
 


### PR DESCRIPTION
(Cc: @Flast)

The SEGV seemed to be caused by [attempting to memfclose() things that are not memfopen()ed](https://github.com/mattn/growl-for-linux/blob/df94cf7d376f76d3cb07f06fa72a2238ce604a75/plugins/from_url.c#L154).
Please take a look at this small patch. Thanks.
