### PR TITLE
Extract response information by using libcurl

### DIFF
--- a/plugins/from_url.h
+++ b/plugins/from_url.h
@@ -19,6 +19,7 @@ typedef struct
     const char* url;
     MEMFILE**   body;
     size_t (*body_writer)(const char*, size_t, size_t, void*);
+    long*       code;
     double*     csize;
     char**      ctype;
 } memfile_from_url_info;


### PR DESCRIPTION
Fixes [this issue](https://github.com/mattn/growl-for-linux/commit/4497f346400f1e30e1e374819e22874a0cbd757f#plugins/from_url.c-P47).
