### PR TITLE
	support "default_timeout" option in config.db to specify duration time

### DIFF
--- a/display/balloon/balloon.c
+++ b/display/balloon/balloon.c
@@ -53,6 +53,7 @@ typedef struct {
   NOTIFICATION_INFO* ni;
   gint pos;
   gint x, y;
+  gint default_timeout;
   gint timeout;
   gint offset;
   gboolean sticky;
@@ -121,7 +122,7 @@ display_animation_func(gpointer data) {
   }
 
   if (di->timeout > 450) {
-    gtk_window_set_opacity(GTK_WINDOW(di->widget.popup), (double) (500-di->timeout)/50.0*0.8);
+    gtk_window_set_opacity(GTK_WINDOW(di->widget.popup), (double) (di->default_timeout-di->timeout)/50.0*0.8);
   }
 
   if (di->timeout < 50) {
@@ -304,7 +305,12 @@ create_popup_skelton() {
 
 static inline DISPLAY_INFO*
 reset_display_info(DISPLAY_INFO* const di, NOTIFICATION_INFO* const ni) {
-  di->timeout = 500;
+  if (ni) {
+    di->default_timeout = ni->timeout;
+    di->timeout = ni->timeout;
+  } else {
+    di->timeout = di->default_timeout;
+  }
   di->offset  = 0;
   di->pos     = 0;
   di->hover   = FALSE;
@@ -328,6 +334,8 @@ static inline DISPLAY_INFO*
 get_popup_skelton(NOTIFICATION_INFO* const ni) {
   DISPLAY_INFO* const di = (DISPLAY_INFO*) list_pop_front(&popup_collections);
   if (di) {
+    di->default_timeout = ni->timeout;
+    di->timeout = ni->timeout;
     di->ni = ni;
     return di;
   }

--- a/display/fog/fog.c
+++ b/display/fog/fog.c
@@ -49,6 +49,7 @@ typedef struct {
   NOTIFICATION_INFO* ni;
   gint pos;
   gint x, y;
+  gint default_timeout;
   gint timeout;
   gint offset;
   gboolean sticky;
@@ -294,7 +295,12 @@ create_popup_skelton() {
 
 static inline DISPLAY_INFO*
 reset_display_info(DISPLAY_INFO* const di, NOTIFICATION_INFO* const ni) {
-  di->timeout = 500;
+  if (ni) {
+    di->default_timeout = ni->timeout;
+    di->timeout = ni->timeout;
+  } else {
+    di->timeout = di->default_timeout;
+  }
   di->pos     = 0;
   di->offset  = 0;
   di->hover   = FALSE;
@@ -318,6 +324,8 @@ static inline DISPLAY_INFO*
 get_popup_skelton(NOTIFICATION_INFO* const ni) {
   DISPLAY_INFO* const di = (DISPLAY_INFO*) list_pop_front(&popup_collections);
   if (di) {
+    di->default_timeout = ni->timeout;
+    di->timeout = ni->timeout;
     di->ni = ni;
     return di;
   }

--- a/gol.c
+++ b/gol.c
@@ -331,6 +331,21 @@ set_display_parameter(const char* const name, const char* const value) {
   exec_sqlite3("insert into display(name, parameter) values('%q', '%q')", name, value);
 }
 
+static gint
+get_config_value(const char* const key, const gint def) {
+  gchar* data;
+  gint value;
+  void
+  get_string(sqlite3_stmt* const stmt) {
+    data = sqlite3_step(stmt) == SQLITE_ROW
+          ? (char*) sqlite3_column_text(stmt, 0): "";
+  }
+  statement_sqlite3(get_string,
+      "select value from config where key = '%q'", key);
+  value = g_ascii_strtoll(data, NULL, 10);
+  return value != 0 ? value : def;
+}
+
 static gchar*
 get_config_string(const char* const key, const char* const def) {
   gchar* value;
@@ -1243,6 +1258,7 @@ raise_notification(const CLIENT_INFO ci, NOTIFICATION_INFO* const ni) {
     cp = find_display_plugin_or(is_sdn, current_display);
   }
 
+  ni->timeout = get_config_value("default_timeout", 5000)/10;
   g_idle_add((GSourceFunc) cp->show, ni); // call once
   return true;
 }

--- a/gol.h
+++ b/gol.h
@@ -42,6 +42,7 @@ typedef struct {
   gchar* icon;
   gchar* url;
   gboolean local;
+  gint timeout;
 } NOTIFICATION_INFO;
 
 typedef struct {


### PR DESCRIPTION
I want to customize duration time, so add "default_timeout" option in config.db.
If the value of default_timeout in config table is 1000, it means duration time is 1000 milliseconds.
