### PR TITLE
Support sticky for libnotify

### DIFF
--- a/display/libnotify/notify.c
+++ b/display/libnotify/notify.c
@@ -75,6 +75,9 @@ display_show(gpointer data) {
     g_object_unref(pixbuf);
   }
 
+  if (ni->sticky)
+    notify_notification_set_urgency(nt, NOTIFY_URGENCY_CRITICAL);
+
   GError* error = NULL;
   if (!notify_notification_show(nt, &error))
   {


### PR DESCRIPTION
Use "urgency level = critial".
