### PR TITLE
Support AppIndicator

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,8 +5,8 @@ SUBDIRS = plugins data \
 
 bin_PROGRAMS = gol
 gol_SOURCES = gol.c gol.h compatibility.h
-gol_CFLAGS = $(GTK2_CFLAGS) $(OPENSSL_CFLAGS) $(SQLITE3_CFLAGS) -DDATADIR='"$(pkgdatadir)"' -DLIBDIR='"$(pkglibdir)"'
-gol_LDADD = $(GTK2_LIBS) $(OPENSSL_LIBS) $(SQLITE3_LIBS) $(GMODULE2_LIBS)
+gol_CFLAGS = $(GTK2_CFLAGS) $(OPENSSL_CFLAGS) $(SQLITE3_CFLAGS) $(APP_INDICATOR_CFLAGS) -DDATADIR='"$(pkgdatadir)"' -DLIBDIR='"$(pkglibdir)"'
+gol_LDADD = $(GTK2_LIBS) $(OPENSSL_LIBS) $(SQLITE3_LIBS) $(GMODULE2_LIBS) $(APP_INDICATOR_LIBS) 
 
 EXTRA_DIST = gol.rc Makefile.w32 README.mkd TODO data/gol.desktop VERSION
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,26 @@ PKG_CHECK_MODULES(NOTIFY, libnotify,
                    AC_CONFIG_FILES([display/libnotify/Makefile])],
                   [ENABLE_LIBNOTIFY=""])
 
+APPINDICATOR_REQUIRED=0.4.92
+AC_ARG_ENABLE(appindicator,
+              AS_HELP_STRING([--enable-appindicator[=@<:@no/auto/yes@:>@]],
+                             [Build support for application indicators ]),
+              [enable_appindicator=$enableval],
+              [enable_appindicator="auto"])
+if test x$enable_appindicator = xauto ; then
+        PKG_CHECK_EXISTS([appindicator-0.1 >= $APPINDICATOR_REQUIRED],
+                         enable_appindicator="yes",
+                         enable_appindicator="no")
+fi
+if test x$enable_appindicator = xyes ; then
+        PKG_CHECK_EXISTS([appindicator-0.1 >= $APPINDICATOR_REQUIRED],,
+                         AC_MSG_ERROR([appindicator-0.1 is not installed]))
+        PKG_CHECK_MODULES(APP_INDICATOR,
+                          appindicator-0.1 >= $APPINDICATOR_REQUIRED)
+        AC_DEFINE(HAVE_APP_INDICATOR, [1], [Have AppIndicator])
+fi
+AM_CONDITIONAL(HAVE_APP_INDICATOR, test x"$enable_appindicator" = xyes)
+
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h memory.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/socket.h unistd.h])
 


### PR DESCRIPTION
Systray whitelist has been deprecated since Ubuntu 13.04,
so AppIndicator support is needed.
