### PR TITLE
Change deprecated des_ to DES_

### DIFF
--- a/gol.c
+++ b/gol.c
@@ -1415,18 +1415,18 @@ gntp_recv_proc(gpointer user_data) {
             r-(ptr-top)-6, &aeskey, (unsigned char*) iv, AES_DECRYPT);
       }
       else if (!strcmp(crypt_algorythm, "DES")) {
-        des_key_schedule schedule;
+        DES_key_schedule schedule;
         DES_set_key_unchecked((const_DES_cblock*) &digest, &schedule);
         DES_ncbc_encrypt((unsigned char*) ptr, (unsigned char*) data,
             r-(ptr-top)-6, &schedule, (const_DES_cblock*) &iv, DES_DECRYPT);
       }
       else if (!strcmp(crypt_algorythm, "3DES")) {
-        des_key_schedule schedule1, schedule2, schedule3;
+        DES_key_schedule schedule1, schedule2, schedule3;
         DES_set_key_unchecked((const_DES_cblock*) (digest+ 0), &schedule1);
         DES_set_key_unchecked((const_DES_cblock*) (digest+ 8), &schedule2);
         DES_set_key_unchecked((const_DES_cblock*) (digest+16), &schedule3);
-        des_ede3_cbc_encrypt((unsigned char*) ptr, (unsigned char*) data,
-            r-(ptr-top)-6, schedule1, schedule2, schedule3,
+        DES_ede3_cbc_encrypt((unsigned char*) ptr, (unsigned char*) data,
+            r-(ptr-top)-6, &schedule1, &schedule2, &schedule3,
             (const_DES_cblock*) &iv, DES_DECRYPT);
       } else {
         data = strdup(ptr);


### PR DESCRIPTION
This code uses a mix of old and deprecated des_ and new DES_ methods and structs. This makes e.g. LibreSSL fail and perhaps OpenSSL 1.0.2 (coming 1.0.3 sure)