### PR TITLE
debian: fix email address

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -152,343 +152,343 @@ growl-for-linux (0.7.7-1raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Sat, 21 Sep 2013 14:36:57 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 21 Sep 2013 14:36:57 +0900
 
 growl-for-linux (0.7.7-1quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Sat, 21 Sep 2013 14:36:42 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 21 Sep 2013 14:36:42 +0900
 
 growl-for-linux (0.7.7-1precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Sat, 21 Sep 2013 14:36:25 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 21 Sep 2013 14:36:25 +0900
 
 growl-for-linux (0.7.7-1oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Sat, 21 Sep 2013 14:36:09 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 21 Sep 2013 14:36:09 +0900
 
 growl-for-linux (0.7.7-1natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Sat, 21 Sep 2013 14:35:53 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 21 Sep 2013 14:35:53 +0900
 
 growl-for-linux (0.7.7-1maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Sat, 21 Sep 2013 14:35:36 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 21 Sep 2013 14:35:36 +0900
 
 growl-for-linux (0.7.7-1lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Sat, 21 Sep 2013 14:35:11 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 21 Sep 2013 14:35:11 +0900
 
 growl-for-linux (0.7.6-1raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:09:43 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:09:43 +0900
 
 growl-for-linux (0.7.6-1quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:09:28 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:09:28 +0900
 
 growl-for-linux (0.7.6-1precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:09:13 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:09:13 +0900
 
 growl-for-linux (0.7.6-1oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:08:59 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:08:59 +0900
 
 growl-for-linux (0.7.6-1natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:08:44 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:08:44 +0900
 
 growl-for-linux (0.7.6-1maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:08:30 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:08:30 +0900
 
 growl-for-linux (0.7.6-1lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:08:15 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:08:15 +0900
 
 growl-for-linux (0.7.5-3raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:04:52 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:04:52 +0900
 
 growl-for-linux (0.7.5-3quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:04:38 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:04:38 +0900
 
 growl-for-linux (0.7.5-3precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:04:23 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:04:23 +0900
 
 growl-for-linux (0.7.5-3oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:04:08 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:04:08 +0900
 
 growl-for-linux (0.7.5-3natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:03:52 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:03:52 +0900
 
 growl-for-linux (0.7.5-3maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:03:37 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:03:37 +0900
 
 growl-for-linux (0.7.5-3lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:03:22 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:03:22 +0900
 
 growl-for-linux (0.7.5-2raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:02:24 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:02:24 +0900
 
 growl-for-linux (0.7.5-2quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:02:09 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:02:09 +0900
 
 growl-for-linux (0.7.5-2precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:01:50 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:01:50 +0900
 
 growl-for-linux (0.7.5-2oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:01:35 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:01:35 +0900
 
 growl-for-linux (0.7.5-2natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:01:19 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:01:19 +0900
 
 growl-for-linux (0.7.5-2maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:01:03 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:01:03 +0900
 
 growl-for-linux (0.7.5-2lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:00:35 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:00:35 +0900
 
 growl-for-linux (-2lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Fri, 20 Sep 2013 01:00:28 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 20 Sep 2013 01:00:28 +0900
 
 growl-for-linux (0.7.5-2raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:59:48 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:59:48 +0900
 
 growl-for-linux (0.7.5-2quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:59:32 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:59:32 +0900
 
 growl-for-linux (0.7.5-2precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:59:18 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:59:18 +0900
 
 growl-for-linux (0.7.5-2oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:59:03 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:59:03 +0900
 
 growl-for-linux (0.7.5-2natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:58:48 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:58:48 +0900
 
 growl-for-linux (0.7.5-2maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:58:33 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:58:33 +0900
 
 growl-for-linux (0.7.5-2lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:58:12 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:58:12 +0900
 
 growl-for-linux (0.7.5-2raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:56:29 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:56:29 +0900
 
 growl-for-linux (0.7.5-2quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:56:25 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:56:25 +0900
 
 growl-for-linux (0.7.5-2precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:56:21 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:56:21 +0900
 
 growl-for-linux (0.7.5-2oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:56:17 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:56:17 +0900
 
 growl-for-linux (0.7.5-2natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:56:13 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:56:13 +0900
 
 growl-for-linux (0.7.5-2maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:56:09 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:56:09 +0900
 
 growl-for-linux (0.7.5-2lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:56:05 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:56:05 +0900
 
 growl-for-linux (0.7.5-2raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:54:23 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:54:23 +0900
 
 growl-for-linux (0.7.5-2quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:54:19 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:54:19 +0900
 
 growl-for-linux (0.7.5-2precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:54:15 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:54:15 +0900
 
 growl-for-linux (0.7.5-2oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:54:11 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:54:11 +0900
 
 growl-for-linux (0.7.5-2natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:54:07 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:54:07 +0900
 
 growl-for-linux (0.7.5-2maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:54:03 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:54:03 +0900
 
 growl-for-linux (0.7.5-2lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:53:59 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:53:59 +0900
 
 growl-for-linux (0.7.5-2raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:47:28 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:47:28 +0900
 
 growl-for-linux (0.7.5-2quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:47:24 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:47:24 +0900
 
 growl-for-linux (0.7.5-2precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:47:20 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:47:20 +0900
 
 growl-for-linux (0.7.5-2oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:47:16 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:47:16 +0900
 
 growl-for-linux (0.7.5-2natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:47:13 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:47:13 +0900
 
 growl-for-linux (0.7.5-2maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:47:09 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:47:09 +0900
 
 growl-for-linux (0.7.5-2lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Sat, 13 Jul 2013 03:47:02 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 13 Jul 2013 03:47:02 +0900
 
 growl-for-linux (0.7.3-2raring) raring; urgency=low
 
@@ -746,145 +746,145 @@ growl-for-linux (0.7.1-1raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Mon, 27 May 2013 00:31:05 +0900
+ -- mattn <mattn.jp@gmail.com>  Mon, 27 May 2013 00:31:05 +0900
 
 growl-for-linux (0.7.1-1quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Mon, 27 May 2013 00:30:56 +0900
+ -- mattn <mattn.jp@gmail.com>  Mon, 27 May 2013 00:30:56 +0900
 
 growl-for-linux (0.7.1-1precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Mon, 27 May 2013 00:30:46 +0900
+ -- mattn <mattn.jp@gmail.com>  Mon, 27 May 2013 00:30:46 +0900
 
 growl-for-linux (0.7.1-1oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Mon, 27 May 2013 00:30:36 +0900
+ -- mattn <mattn.jp@gmail.com>  Mon, 27 May 2013 00:30:36 +0900
 
 growl-for-linux (0.7.1-1maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Mon, 27 May 2013 00:30:27 +0900
+ -- mattn <mattn.jp@gmail.com>  Mon, 27 May 2013 00:30:27 +0900
 
 growl-for-linux (0.7.1-1natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Mon, 27 May 2013 00:29:55 +0900
+ -- mattn <mattn.jp@gmail.com>  Mon, 27 May 2013 00:29:55 +0900
 
 growl-for-linux (0.7.0-raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Sun, 26 May 2013 01:12:21 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 26 May 2013 01:12:21 +0900
 
 growl-for-linux (0.7.0-1raring) raring; urgency=low
 
   * backport to dist raring
 
- -- mattn <mattn@donkey>  Sun, 26 May 2013 01:12:04 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 26 May 2013 01:12:04 +0900
 
 growl-for-linux (0.7.0-quantal) quantal; urgency=low
 
   * backport to dist quantal
 
- -- mattn <mattn@donkey>  Sun, 14 Oct 2012 01:21:48 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 14 Oct 2012 01:21:48 +0900
 
 growl-for-linux (0.7.0-precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Sun, 14 Oct 2012 01:21:38 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 14 Oct 2012 01:21:38 +0900
 
 growl-for-linux (0.7.0-oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Sun, 14 Oct 2012 01:21:27 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 14 Oct 2012 01:21:27 +0900
 
 growl-for-linux (0.7.0-maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Sun, 14 Oct 2012 01:21:17 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 14 Oct 2012 01:21:17 +0900
 
 growl-for-linux (0.7.0-natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Sun, 14 Oct 2012 01:21:07 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 14 Oct 2012 01:21:07 +0900
 
 growl-for-linux (0.7.0-lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Sun, 14 Oct 2012 01:20:54 +0900
+ -- mattn <mattn.jp@gmail.com>  Sun, 14 Oct 2012 01:20:54 +0900
 
 growl-for-linux (0.6.9-1precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Fri, 03 Aug 2012 00:35:04 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 03 Aug 2012 00:35:04 +0900
 
 growl-for-linux (0.6.9-1oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Fri, 03 Aug 2012 00:34:54 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 03 Aug 2012 00:34:54 +0900
 
 growl-for-linux (0.6.9-1maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Fri, 03 Aug 2012 00:34:45 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 03 Aug 2012 00:34:45 +0900
 
 growl-for-linux (0.6.9-1natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Fri, 03 Aug 2012 00:34:35 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 03 Aug 2012 00:34:35 +0900
 
 growl-for-linux (0.6.9-1lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Fri, 03 Aug 2012 00:34:16 +0900
+ -- mattn <mattn.jp@gmail.com>  Fri, 03 Aug 2012 00:34:16 +0900
 
 growl-for-linux (0.6.8-1precise) precise; urgency=low
 
   * backport to dist precise
 
- -- mattn <mattn@donkey>  Sat, 12 May 2012 23:43:29 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 12 May 2012 23:43:29 +0900
 
 growl-for-linux (0.6.8-1oneiric) oneiric; urgency=low
 
   * backport to dist oneiric
 
- -- mattn <mattn@donkey>  Sat, 12 May 2012 23:43:20 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 12 May 2012 23:43:20 +0900
 
 growl-for-linux (0.6.8-1maverick) maverick; urgency=low
 
   * backport to dist maverick
 
- -- mattn <mattn@donkey>  Sat, 12 May 2012 23:43:10 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 12 May 2012 23:43:10 +0900
 
 growl-for-linux (0.6.8-1natty) natty; urgency=low
 
   * backport to dist natty
 
- -- mattn <mattn@donkey>  Sat, 12 May 2012 23:43:01 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 12 May 2012 23:43:01 +0900
 
 growl-for-linux (0.6.8-1lucid) lucid; urgency=low
 
   * backport to dist lucid
 
- -- mattn <mattn@donkey>  Sat, 12 May 2012 23:42:47 +0900
+ -- mattn <mattn.jp@gmail.com>  Sat, 12 May 2012 23:42:47 +0900
 
 growl-for-linux (0.6.7-1oneiric) oneiric; urgency=low
 


### PR DESCRIPTION
lintian reports as error:

  E: growl-for-linux: debian-changelog-file-contains-invalid-email-address mattn@donkey