### PR TITLE
Fix license to reflect Simplified BSD

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,7 @@
-Copyright 2011 by Yasuhiro Matsumoto
+Copyright (c) 2011, Yasuhiro Matsumoto
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice,
@@ -8,10 +11,10 @@ modification, are permitted provided that the following conditions are met:
    and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
 FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
 (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)


### PR DESCRIPTION
Hi! 

I'm looking into including your project into Fedora at some point and would really appreciate if you could accept some changes to your license as to not have any confusion about there being errors. I took the liberty to make this pull request to reflect changes going toward a verbatim [Simplified BSD](https://en.wikipedia.org/wiki/BSD_licenses#2-clause) license. (It seems to be the closest). I also went ahead and did some diff renderings as well:

---
#### 1. Simplified BSD (or 2-clause):

vimdiff: https://xenithorb.github.io/growl-for-linux/2-current_license_to_wiki-Simplified-BSD.html
txt: https://xenithorb.github.io/growl-for-linux/2-COPYING

---
#### 2. FreeBSD License (Verbatim):

vimdiff: https://xenithorb.github.io/growl-for-linux/1-current_license_to_FreeBSD_verbatim.html
txt: https://xenithorb.github.io/growl-for-linux/1-COPYING

---

Please consider reviewing the above proposals and updating with a PR comment here with your wishes. From there I can modify the PR and you can merge as necessary. 

Thank you :)

Edit: Forgot to include, the right-hand-side title to the vimdiff file contains a link to the original source. 

For Simplified BSD, I used: https://en.wikipedia.org/wiki/BSD_licenses#2-clause
For FreeBSD License, I used: https://www.freebsd.org/copyright/freebsd-license.html
