### PR TITLE
Drop removed growl4linux.jpg image from the rule

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,4 +1,4 @@
 icondir = $(pkgdatadir)/data
-icon_DATA = growl4linux.jpg icon.png icon_dnd.png mattn.png
+icon_DATA = icon.png icon_dnd.png mattn.png
 
 EXTRA_DIST = $(icon_DATA) display_balloon.png display_default.png display_nico2.png gol.ico screenshot.png


### PR DESCRIPTION
This commit fixes the following error:

make[1]: Entering directory '/home/kenhys/work/growl/growl-for-linux/growl-for-linux/data'
make[1]: **\* No rule to make target 'growl4linux.jpg', needed by 'all-am'.  Stop.
make[1]: Leaving directory '/home/kenhys/work/growl/growl-for-linux/growl-for-linux/data'
Makefile:546: recipe for target 'all-recursive' failed
