### PR TITLE
Remove useless empty NEWS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT([growl-for-linux], m4_esyscmd([cat VERSION | tr -d '\n']), [mattn.jp@gma
 AC_CONFIG_SRCDIR([gol.c])
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 
 # Smart output for automake.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
The foreign option implies to check existence of NEWS, so there is no
need to touch NEWS file.

Ref. http://www.gnu.org/software/automake/manual/automake.html#index-Strictness_002c-foreign
