### PR TITLE
Use smaller image for about dialog

### DIFF
--- a/gol.c
+++ b/gol.c
@@ -1152,7 +1152,7 @@ about_click(GtkWidget* GOL_UNUSED_ARG(widget), gpointer GOL_UNUSED_ARG(user_data
       "http://mattn.kaoriya.net/");
   {
     GdkPixbuf* logo = pixbuf_from_datadir("icon.png", NULL);
-    gtk_about_dialog_set_logo (GTK_ABOUT_DIALOG(about_dialog), logo);
+    gtk_about_dialog_set_logo(GTK_ABOUT_DIALOG(about_dialog), logo);
     g_object_unref(G_OBJECT(logo));
   }
   gtk_window_set_position(GTK_WINDOW(about_dialog), GTK_WIN_POS_CENTER);

--- a/gol.c
+++ b/gol.c
@@ -1151,7 +1151,7 @@ about_click(GtkWidget* GOL_UNUSED_ARG(widget), gpointer GOL_UNUSED_ARG(user_data
   gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(about_dialog),
       "http://mattn.kaoriya.net/");
   {
-    GdkPixbuf* logo = pixbuf_from_datadir("icon.png", NULL);
+    GdkPixbuf* logo = pixbuf_from_datadir("icon256.png", NULL);
     gtk_about_dialog_set_logo(GTK_ABOUT_DIALOG(about_dialog), logo);
     g_object_unref(G_OBJECT(logo));
   }


### PR DESCRIPTION
icon.png is a bit too large for about dialog.

It is not suitable when screen resolution is not enough.  For example,
screen resolution is WXGA (1366x768) - typically for note PC, bottom
buttons are hidden.

![too-large-logo-in-about-dialog](https://cloud.githubusercontent.com/assets/225841/15988961/bf841e22-309f-11e6-9235-c11a63fce96d.png)
