### PR TITLE
Use machine readable copyright format

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1,34 +1,41 @@
-This work was packaged for Debian by:
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: growl-for-linux
+Upstream-Contact: Yasuhiro Matsumoto <mattn.jp@gmail.com>
+Source: https://github.com/mattn/growl-for-linux
 
-    Yasuhiro Matsumoto <mattn.jp@gmail.com> on Sun, 24 Apr 2011 01:35:52 +0900
+Files: *
+Copyright: 2011-2016 Yasuhiro Matsumoto
+ 2011-2016 Kohei Takahashi
+License: BSD-2-clause
 
-It was downloaded from http://github.com/mattn/growl-for-linux
+Files: debian/*
+Copyright: 2013-2016 Yasuhiro Matsumoto
+ 2016 Kentaro Hayashi
+License: BSD-2-clause
 
-Upstream Author(s):
+Files: display/libnotify/notify.c
+Copyright: 2011 Kohei Takahashi
+License: BSD-2-clause
 
-    Yasuhiro Matsumoto <mattn.jp@gmail.com>
-
-Copyright:
-
-    Copyright (C) 2011 Yasuhiro Matsumoto
-
-License:
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted under the terms of the BSD License.
-
-    THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-    ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-    SUCH DAMAGE.
-
-The Debian packaging is:
-
-    Copyright (C) 2011 Yasuhiro Matsumoto <mattn.jp@gmail.com>
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ 1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Clarifying copyright of software is important, so it is recommended
to describe it in machine readable form to verify it.

Refer https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
