### PR TITLE
debian: use ${shlibs:Depends} instead of hardcoded runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Homepage: http://mattn.github.com/growl-for-linux
 
 Package: growl-for-linux
 Architecture: any
-Depends: libglib2.0-0, libgtk2.0-0, libnotify4, libappindicator1, libcurl3, libxml2, libsqlite3-0, libdbus-glib-1-2, libc6, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Linux compatible of Growl
  Growl For Linux is Linux-compatible of Growl. Growl is a notification system for Mac OS X. 


### PR DESCRIPTION
Lintian reports this kind of stuff as:

  W: growl-for-linux source: package-depends-on-hardcoded-libc
  growl-for-linux depends
