### PR TITLE
debian: add missing TLS library

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: growl-for-linux
 Section: gnome
 Priority: optional
 Maintainer: Yasuhiro Matsumoto <mattn.jp@gmail.com>
-Build-Depends: debhelper (>= 7), autotools-dev, libglib2.0-dev, libgtk2.0-dev, libnotify-dev, libappindicator-dev, libcurl4-openssl-dev, libxml2-dev, libsqlite3-dev, libdbus-glib-1-dev, desktop-file-utils
+Build-Depends: debhelper (>= 7), autotools-dev, libglib2.0-dev, libgtk2.0-dev, libnotify-dev, libappindicator-dev, libcurl4-openssl-dev, libxml2-dev, libsqlite3-dev, libdbus-glib-1-dev, desktop-file-utils, libssl-dev
 Standards-Version: 3.8.4
 Homepage: https://mattn.github.io/growl-for-linux/
 


### PR DESCRIPTION
It is needed for building package in clean room (pbuilder etc.)
