### PR TITLE
debian: add missing watch file

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,3 @@
+version=4
+opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/growl-for-linux-$1\.tar\.gz/ \
+  https://github.com/mattn/growl-for-linux/releases .*/v?(\d\S*)\.tar\.gz


### PR DESCRIPTION
It is used to monitor latest release.

ref. https://wiki.debian.org/debian/watch
